### PR TITLE
Update README.MD

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -56,7 +56,7 @@ List of required packages for every script to work
 
 **Debian**
 ``` 
-apt-get install autoconf bc curl diffutils ftp git libflac-dev libssl-dev lm-sensors lynx make mariadb-server ncftp passwd rsync smartmontools tcl tcl-dev tcllib tcl-tls tcpd wget zip
+apt-get install cron gcc systemd autoconf bc curl diffutils ftp git libflac-dev libssl-dev lm-sensors lynx make mariadb-server ncftp passwd rsync smartmontools tcl tcl-dev tcllib tcl-tls tcpd wget zip
 ``` 
 **BASH** needs to be the default shell. To change from default DASH to BASH in Debian do 
 ``` 


### PR DESCRIPTION
add cron, gcc and systemd of list required packages. This is package was missing on a debian-slim