### PR TITLE
Correction during multiple ips and clarifications

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1749,18 +1749,18 @@ function usercreation
 	fi
 
 	ipbinary=`which ip`
-	localip=`$ipbinary addr show | awk '$1 == "inet" && $3 == "brd" { sub (/\/.*/,""); print $2 }' | head | awk -F "." '{print $1"."$2"."$3.".*"}'`
+	localip=$($ipbinary addr show | awk '$1 == "inet" && $3 == "brd" { sub (/\/.*/,""); print $2 }' | head | awk -F "." '{print "*@"$1"."$2"."$3.".*"}' | xargs)
 	
 	if [[ -f "$cache" && "`cat $cache | grep -w ip | wc -l`" = 1 ]]
 	then
 		ip=`cat $cache | grep -w ip | cut -d "=" -f2 | tr -d "\""`
 	else
-		echo -n "IP for [$username] ? Minimum *@xxx.xxx.* default *@${localip} : " ; read ip
+		echo -n "IP for [$username] ? Minimum *@xxx.xxx.* default ${localip} : " ; read ip
 	fi
 	
 	if [ "$ip" = "" ] 
 	then
-		ip="*@$localip"
+		ip="$localip"
 	fi
 
 	if [ "`cat $cache | grep -w username= | wc -l`" = 0 ]


### PR DESCRIPTION
```
IP for [MyNick] ? Minimum *@xxx.xxx.* default *@192.168.1.*
172.17.0.*
172.19.0.* :
```
This is confusing for the entry to be provided. Should we put '\*@' in front of the ip or not? Create a problem when adding.
My solution always displays '\*@' in front of the 'IPs' and puts them on the same line
this fixes the problem when adding the user
```
IP for [MyNick] ? Minimum *@xxx.xxx.* default *@192.168.1.* *@172.17.0.* *@172.19.0.* :
```
The following command executes correctly
```
ncftpls -u glftpd -p glftpd -P $port -Y "site gadduser Admin $username $password $ip" $connection > /dev/null
```
resultat
```
site gadduser Admin MyNick MyPassword *@192.168.1.* *@172.17.0.* *@172.19.0.*
```
and no :
```
site gadduser Admin MyNick MyPassword *@192.168.1.*
172.17.0.*
172.19.0.*
```
This also allows to define an ident at the prompt if desired without having to change afterwards, like this:

```
IP for [MyNick] ? Minimum *@xxx.xxx.* default *@192.168.1.* *@172.17.0.* *@172.19.0.* :  MyIdent@172.19.0.*
```