### PR TITLE
Fix 'File does not exist in sfv!' STOR+long path

### DIFF
--- a/packages/scripts/tur-precheck/tur-precheck.sh
+++ b/packages/scripts/tur-precheck/tur-precheck.sh
@@ -52,7 +52,7 @@ case "$1" in
         echo -e "You must upload .sfv first!\n"
         exit 2
       else
-        if [ -z "`grep -i "^$1\ " "$sfv_file"`" ]; then
+        if [ -z "`grep -i "^$1\ " "$2/$sfv_file"`" ]; then
           echo -e "File does not exist in sfv!\n"
           exit 2
         fi
@@ -67,7 +67,7 @@ case "$1" in
         echo -e "You must upload .sfv first!\n"
         exit 2
       else
-        if [ -z "`grep -i "^$1\ " "$sfv_file"`" ]; then
+        if [ -z "`grep -i "^$1\ " "$2/$sfv_file"`" ]; then
           echo -e "File does not exist in sfv!\n"
           exit 2
         fi


### PR DESCRIPTION
Corrects the problem when using the long path without entering the directory with STOR. 

As  ```
STOR /!Today-MP3/Relase-name-2000-grp/01-artist-name.mp3
553- File does not exist in sfv! 
```