### PR TITLE
Enhancements to Version Management 

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -54,7 +54,7 @@ List of required packages for every script to work
 
 **Debian**
 ``` 
-apt-get install cron gcc systemd autoconf bc curl diffutils ftp git libflac-dev libssl-dev lm-sensors lynx make mariadb-server ncftp passwd rsync smartmontools tcl tcl-dev tcllib tcl-tls tcpd wget zip bsdmainutils
+apt-get install cron gcc systemd autoconf bc curl diffutils ftp git libflac-dev libssl-dev lm-sensors lynx make mariadb-server ncftp passwd rsync smartmontools tcl tcl-dev tcllib tcl-tls tcpd wget zip bsdmainutils libxml2-utils
 ``` 
 **BASH** needs to be the default shell. To change from default DASH to BASH in Debian do 
 ``` 


### PR DESCRIPTION
🔧 chore(README.MD): add libxml2-utils to the list of required packages for every script to work

🔧 chore(install.sh): refactor version function to improve readability and add support for user selection of glftpd version
 In the "install.sh" script, we have refactored the glFTPd version selection function. This overhaul significantly enhances code readability and now allows users to choose the specific glFTPd version they want to install. To illustrate these changes, we have included a sample user interaction showing how version selection works.
Example:
```
Downloading relevant packages, please wait...
Available versions:
[1] glFTPd v2.14a_for Linux (x64)
[2] glFTPd v2.13a_for Linux (x64)
[3] glFTPd v2.13_BETA1 for Linux (x64)
[4] glFTPd v2.12 for Linux (x64)
[5] glFTPd v2.11a for Linux (x64)
[6] glFTPd v2.11 for Linux (x64)
[7] glFTPd v2.10a for Linux (x64)
Please enter the number of your choice: 1
You selected: glFTPd v2.14a_for Linux (x64)
[Done]
...snip...
```