### PR TITLE
Fix [TRIGGER] formatting in tur-space.conf.new to ensure script functionality

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -194,7 +194,7 @@ function device_name
 	
     fi
     cp packages/scripts/tur-space/tur-space.conf packages/scripts/tur-space/tur-space.conf.new
-    echo "[TRIGGER]\n" >> packages/scripts/tur-space/tur-space.conf.new
+    echo "[TRIGGER]" >> packages/scripts/tur-space/tur-space.conf.new
     echo "TRIGGER=$device:100000:200000" >> packages/scripts/tur-space/tur-space.conf.new
     echo "" >> packages/scripts/tur-space/tur-space.conf.new
     echo "[INCOMING]" >> packages/scripts/tur-space/tur-space.conf.new


### PR DESCRIPTION
This PR fixes a critical issue where the `tur-space.sh` script failed to detect the `[TRIGGER]` category due to an erroneous newline (`\n`) in the configuration file.  

**Changes Made:**  
- Removed the redundant `\n` after `[TRIGGER]` in the `echo` command to ensure proper formatting.  
- Before (bug):  
  ```bash
  echo "[TRIGGER]\n" >> file.conf  # ⚠️ Created an "[TRIGGER]\n" and not "[TRIGGER]" 
  ```  
- After (fixed):  
  ```bash
  echo "[TRIGGER]" >> file.conf   # ✅ Correct format  
  ```  

**Impact:**  
- The `tur-space.sh` script can now correctly parse the `[TRIGGER]` section in the config file.  
- Prevents silent failures in configuration parsing.  
